### PR TITLE
Add deck context to rotary and touch callbacks

### DIFF
--- a/src/StreamDeck/Devices/StreamDeck.py
+++ b/src/StreamDeck/Devices/StreamDeck.py
@@ -149,7 +149,7 @@ class StreamDeck(ABC):
                             for rotary_no in range(0, self.ROTARY_COUNT):
                                 rotary_status.append( hid_states[4 + rotary_no] if hid_states[4 + rotary_no] < 0x80 else -(0x100 - hid_states[4 + rotary_no]) )
                             if self.rotaryturn_callback is not None:
-                                self.rotaryturn_callback(rotary_status)
+                                self.rotaryturn_callback(self, rotary_status)
                         else:
                             # rotary pushed
                             new_rotary_states = [bool(s) for s in hid_states[4:4+self.ROTARY_COUNT]]
@@ -166,13 +166,13 @@ class StreamDeck(ABC):
                         
                         if hid_states[3] != self.TOUCH_EVENT_DRAG:
                             if self.lcdtouch_callback is not None:
-                                self.lcdtouch_callback(hid_states[3],x,y)
+                                self.lcdtouch_callback(self, hid_states[3],x,y)
                         else:
                             # drag event
                             x_out = (hid_states[10]<<8)+hid_states[9]
                             y_out = (hid_states[12]<<8)+hid_states[11]
                             if self.lcdtouch_callback is not None:
-                                self.lcdtouch_callback(hid_states[3],x,y,x_out, y_out)
+                                self.lcdtouch_callback(self, hid_states[3],x,y,x_out, y_out)
                 else:
                     # support for button-only decks
                     new_key_states = hid_states

--- a/src/example_plus.py
+++ b/src/example_plus.py
@@ -74,14 +74,22 @@ def rotary_change(deck, rotary, rotary_state):
         deck.set_lcd_image(0, 0, 800, 100, img_byte_arr)
         
 # callback when rotaries are turned 
-def rotary_turned(values):
+def rotary_turned(deck, values):
     for rotary_no, (value) in enumerate(values):
         if value != 0:
             print("rotary "+ str(rotary_no) +" turned: " + str(value))
-            
+            if rotary_no == 3:
+                newbrightness = min(max(deck.lastbrightness + 10*value,0), 100)
+                if newbrightness == deck.lastbrightness:
+                    print("Brightness limit: {}".format(deck.lastbrightness))
+                else:
+                    print("Setting brightness: {}".format(newbrightness))
+                    deck.set_brightness(newbrightness)
+                    deck.lastbrightness=newbrightness
+
 
 # callback when lcd is touched
-def lcd_touched(event_type, x, y, x_out = 0, y_out = 0):
+def lcd_touched(deck, event_type, x, y, x_out = 0, y_out = 0):
     
     if event_type == deck.TOUCH_EVENT_SHORT:
     
@@ -120,8 +128,9 @@ if __name__ == "__main__":
 
         print("Opened '{}' device (serial number: '{}')".format(deck.deck_type(), deck.get_serial_number()))
 
-        # Set initial screen brightness to 30%.
-        deck.set_brightness(100)
+        # Set initial screen brightness to 50%.
+        deck.set_brightness(50)
+        deck.lastbrightness=50 # preserve value in this deck's context
 
         
         for key in range(0, deck.KEY_COUNT):


### PR DESCRIPTION
This context is required if you have multiple stream deck plus devices.